### PR TITLE
Remove gem update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ env:
   - RAILS_MASTER_KEY=b8cc3ac9ab8a3280b03af3d29b2e50ca
 
 before_install:
-  - gem update --system
-  - gem install bundler
   - nvm install 12
   - node -v
   - npm i -g yarn@^1.15.2


### PR DESCRIPTION
Prevents this:
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-2.6.5/bin/bundle
Overwrite the executable? [yN]  

Ref: https://travis-ci.community/t/our-builds-started-failing-with-bundlers-executable-bundle-conflicts/6523