### PR TITLE
Add Dependabot minimum package age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,17 @@ updates:
     schedule:
       interval: weekly
       time: "04:00"
+    cooldown:
+      default-days: 5
   - package-ecosystem: bundler
     directory: "/"
     schedule:
       interval: weekly
       time: "04:00"
+    cooldown:
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: pry-byebug
@@ -33,6 +39,10 @@ updates:
     schedule:
       interval: weekly
       time: "04:00"
+    cooldown:
+      semver-patch-days: 5
+      semver-minor-days: 10
+      semver-major-days: 15
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: exports-loader


### PR DESCRIPTION
Delay Dependabot updates so new releases are not proposed immediately after publication, reducing exposure to supply chain attacks during the first few days after release.

Use semver-specific cooldowns for Bundler and npm updates, with a five-day fallback for GitHub Actions where per-update values are not available.